### PR TITLE
Additional QoL operations to BoolRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 [z3](https://github.com/Z3Prover/z3) with some improvements:
 * Change the right shift operation on `BitVec`'s to be logical instead of arithmetic
-* Change the multiplication operation on `BoolRef`'s to utilize `And()`
-* Added the addition operation to `BoolRef`'s utilizing `Or()`
-* Added the invertion (`~`) operation to `BoolRef`'s utilizing `Not()`
+* Extend the `*` operation between `BoolRef`'s to work between two `BoolRef`'s.
+* Add additional operations to `BoolRef`'s:
+  * `+`, returning an Int kind such that e.g `True+True+False==2`
+  * `&`, utilizing `And()`
+  * `|`, utilizing `Or()`
+  * `~`, utilizing `Not()`
 * Add the `ByteVec` class
 * Some helper methods for solving:
   * `easy_solve`

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [z3](https://github.com/Z3Prover/z3) with some improvements:
 * Change the right shift operation on `BitVec`'s to be logical instead of arithmetic
+* Change the multiplication operation on `BoolRef`'s to work like `And()`
+* Added the addition operation to `BoolRef`'s and made it work like `Or()`
+* Added the invertion (`~`) operation to `BoolRef`'s and made it work like `Not()`
 * Add the `ByteVec` class
 * Some helper methods for solving:
   * `easy_solve`

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [z3](https://github.com/Z3Prover/z3) with some improvements:
 * Change the right shift operation on `BitVec`'s to be logical instead of arithmetic
-* Change the multiplication operation on `BoolRef`'s to work like `And()`
-* Added the addition operation to `BoolRef`'s and made it work like `Or()`
-* Added the invertion (`~`) operation to `BoolRef`'s and made it work like `Not()`
+* Change the multiplication operation on `BoolRef`'s to utilize `And()`
+* Added the addition operation to `BoolRef`'s utilizing `Or()`
+* Added the invertion (`~`) operation to `BoolRef`'s utilizing `Not()`
 * Add the `ByteVec` class
 * Some helper methods for solving:
   * `easy_solve`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [z3](https://github.com/Z3Prover/z3) with some improvements:
 * Change the right shift operation on `BitVec`'s to be logical instead of arithmetic
-* Extend the `*` operation between `BoolRef`'s to work between two `BoolRef`'s.
+* Extend the `*` operation on `BoolRef`'s to work between two `BoolRef`'s.
 * Add additional operations to `BoolRef`'s:
   * `+`, returning an Int kind such that e.g `True+True+False==2`
   * `&`, utilizing `And()`

--- a/z4.py
+++ b/z4.py
@@ -162,6 +162,15 @@ def _test():
     assert s2.check() == z3.sat
     assert text.value(s2.model()) == b"FOO"
 
+    x,y = z3.Ints('x y')
+    s3 = z3.Solver()
+    s3.add( ((x==4)|(x<0)) + (~(x==y)&(y==4))*(x**2==y)*1 + (x==1337)*0 == 2 )
+    assert s3.check() == z3.sat
+    m3 = s3.model()
+
+    assert m3[x] == -2
+    assert m3[y] == 4
+
 
 if __name__ == "__main__":
     _test()

--- a/z4.py
+++ b/z4.py
@@ -65,22 +65,22 @@ z3.BitVecRef.__rshift__ = z3.LShR
 z3.BitVecRef.__rrshift__ = lambda a, b: z3.LShR(b, a)
 
 
-z3.BoolRef.__and__ = And
+z3.BoolRef.__and__ = z3.And
 z3.BoolRef.__rand__ = lambda a, b: a & b
 
-z3.BoolRef.__or__ = Or
+z3.BoolRef.__or__ = z3.Or
 z3.BoolRef.__ror__ = lambda a, b: a | b
 
-z3.BoolRef.__xor__ = Xor
+z3.BoolRef.__xor__ = z3.Xor
 z3.BoolRef.__rxor__ = lambda a, b: a ^ b
 
-z3.BoolRef.__invert__ = Not
+z3.BoolRef.__invert__ = z3.Not
 
-z3.BoolRef.__add__ = lambda a, b: BoolToInt(a) + (BoolToInt(b) if isinstance(b, BoolRef) else b)
+z3.BoolRef.__add__ = lambda a, b: BoolToInt(a) + (BoolToInt(b) if isinstance(b, z3.BoolRef) else b)
 z3.BoolRef.__radd__ = lambda a, b: a + b
 
 _original_bool_ref_mul = z3.BoolRef.__mul__
-z3.BoolRef.__mul__ = lambda a, b: BoolToInt(a) * BoolToInt(b) if isinstance(b, BoolRef) else _original_bool_ref_mul(a, b)
+z3.BoolRef.__mul__ = lambda a, b: BoolToInt(a) * BoolToInt(b) if isinstance(b, z3.BoolRef) else _original_bool_ref_mul(a, b)
 z3.BoolRef.__rmul__ = lambda a, b: a * b
 
 

--- a/z4.py
+++ b/z4.py
@@ -65,13 +65,23 @@ z3.BitVecRef.__rshift__ = z3.LShR
 z3.BitVecRef.__rrshift__ = lambda a, b: z3.LShR(b, a)
 
 
-z3.BoolRef.__add__ = lambda self, other: Or(self, other)
-z3.BoolRef.__radd__ = lambda self, other: self + other
+z3.BoolRef.__and__ = And
+z3.BoolRef.__rand__ = lambda a, b: a & b
 
-z3.BoolRef.__mul__ = lambda self, other: And(self, other)
-z3.BoolRef.__rmul__ = lambda self, other: self * other
+z3.BoolRef.__or__ = Or
+z3.BoolRef.__ror__ = lambda a, b: a | b
 
-z3.BoolRef.__invert__ = lambda self: Not(self)
+z3.BoolRef.__xor__ = Xor
+z3.BoolRef.__rxor__ = lambda a, b: a ^ b
+
+z3.BoolRef.__invert__ = Not
+
+z3.BoolRef.__add__ = lambda a, b: BoolToInt(a) + (BoolToInt(b) if isinstance(b, BoolRef) else b)
+z3.BoolRef.__radd__ = lambda a, b: a + b
+
+z3.BoolRef.__mul__ = lambda a, b: BoolToInt(a) * (BoolToInt(b) if isinstance(b, BoolRef) else b)
+z3.BoolRef.__rmul__ = lambda a, b: a * b
+
 
 
 class ByteVec(z3.BitVecRef):

--- a/z4.py
+++ b/z4.py
@@ -79,7 +79,8 @@ z3.BoolRef.__invert__ = Not
 z3.BoolRef.__add__ = lambda a, b: BoolToInt(a) + (BoolToInt(b) if isinstance(b, BoolRef) else b)
 z3.BoolRef.__radd__ = lambda a, b: a + b
 
-z3.BoolRef.__mul__ = lambda a, b: BoolToInt(a) * (BoolToInt(b) if isinstance(b, BoolRef) else b)
+_original_bool_ref_mul = z3.BoolRef.__mul__
+z3.BoolRef.__mul__ = lambda a, b: BoolToInt(a) * BoolToInt(b) if isinstance(b, BoolRef) else _original_bool_ref_mul(a, b)
 z3.BoolRef.__rmul__ = lambda a, b: a * b
 
 

--- a/z4.py
+++ b/z4.py
@@ -65,6 +65,15 @@ z3.BitVecRef.__rshift__ = z3.LShR
 z3.BitVecRef.__rrshift__ = lambda a, b: z3.LShR(b, a)
 
 
+z3.BoolRef.__add__ = lambda self, other: Or(self, other)
+z3.BoolRef.__radd__ = lambda self, other: self + other
+
+z3.BoolRef.__mul__ = lambda self, other: And(self, other)
+z3.BoolRef.__rmul__ = lambda self, other: self * other
+
+z3.BoolRef.__invert__ = lambda self: Not(self)
+
+
 class ByteVec(z3.BitVecRef):
     def __init__(self, name, byte_count, ctx=None):
         self.byte_count = byte_count


### PR DESCRIPTION
When chaining together boolean expressions there has always a need to add `And()`  and `Or()` surrounding everything and passing the expressions as arguments. This can become very cluttered and clumsy when working under time constraints (e.g CTF challenges).

This PR modifies `*` and adds `+` and `~` to BoolRef. This makes for example `(x==2)*(y==3)+(x==1)*~(y==3)` possible, instead of `Or(And(x==2,y==3), And(x==1,Not(y==3)))`

The multiplication operation on BoolRefs is currently quite useless, but this could be breaking hence I'm submitting this here and not to the official z3 repo (plus this is what I usually use, `find_all_solutions` is the best :) )